### PR TITLE
Fix CodeQL Security Alert: Move BuildDate from const to var

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -12,12 +12,12 @@ const (
 
 	// APIVersion is the version of the MCP protocol.
 	APIVersion = "0.1.0"
-
-	// BuildDate can be set at build time using ldflags.
-	BuildDate = ""
 )
 
 var (
+	// BuildDate can be set at build time using ldflags.
+	BuildDate = "" //nolint:gochecknoglobals // Build-time variable set via ldflags
+
 	// GitCommit can be set at build time using ldflags.
 	GitCommit = "dev" //nolint:gochecknoglobals // Build-time variable set via ldflags
 


### PR DESCRIPTION
## Summary
Resolves CodeQL security alert about comparison of identical expressions in version.go

## Problem
CodeQL detected that `BuildDate` was defined as a const with empty string value, making the comparison `buildDate == ""` always evaluate to true (comparison of identical expressions).

## Solution  
- Move `BuildDate` from const block to var block
- This allows `BuildDate` to be properly set at build time via ldflags
- Maintains existing API compatibility
- Resolves the CodeQL security alert

## Testing
- ✅ All existing tests pass
- ✅ Application builds and runs correctly  
- ✅ Version information still works as expected

## CodeQL Alert
- **Alert**: go/comparison-of-identical-expressions
- **Severity**: Warning  
- **Status**: Will be resolved after merge

This fix enables proper build-time variable injection while maintaining backward compatibility.